### PR TITLE
Changed colour of text for RPi GPIO pin selection

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1867,6 +1867,10 @@ color: #DDD;
   color: #888 !important;
 }
 
+.rpi-gpio-pinTable {
+  color: #666;
+}
+
 .sidebar-footer-button {
   color: #AAA !important;
   background-color: #434954;

--- a/theme.css
+++ b/theme.css
@@ -1868,7 +1868,7 @@ color: #DDD;
 }
 
 .rpi-gpio-pinTable {
-  color: #666;
+  color: #555;
 }
 
 .sidebar-footer-button {


### PR DESCRIPTION
Not sure if this is the best way to make the change but thought I'd give it a go rather than raising an issue.

Before:

![image](https://user-images.githubusercontent.com/37967220/76690530-b923f580-66a5-11ea-9ad6-586e19d19c8a.png)

After:

![image](https://user-images.githubusercontent.com/37967220/76690536-c345f400-66a5-11ea-957e-834fcfa029ac.png)
