### PR TITLE
Improved node highlighting

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -2956,3 +2956,16 @@ ul.red-ui-sidebar-node-config-list .red-ui-palette-node {
 ul.red-ui-sidebar-node-config-list li.red-ui-palette-node-config-type {
   color: #AAA;
 }
+
+.red-ui-flow-node-highlighted {
+  stroke: #db1b14;
+  stroke-width: 4;
+  stroke-dasharray: 8,4;
+  animation: marchingAnts 47s linear forwards;
+  animation-iteration-count:infinite;
+}
+@keyframes marchingAnts {
+  to {
+    stroke-dashoffset: 500;
+  }
+}


### PR DESCRIPTION
When I search for a node, it's really hard to see, especially since the outline is orange and function nodes are a slightly different shade of orange.

Hovering over a debug message also highlights the node that emitted the debug message, but it's very hard to see the node in question due to the orange highlighting.

This PR changes the orange node highlighting to red and adds an animation to make it easier to see when you hover over a debug message.